### PR TITLE
Added explanation of CSV fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ python output_csv_validator.py --csv /path/to/data.csv
 | title  | The title of the article  | Yes  |
 | publication | The title of the issue | Yes |
 | abstract  | The abstract of the article  | Yes  |
-| file  |   | Yes  |
-| publication_date  |   | Yes  |
-| volume  |   | Yes  |
-| year  |   | Yes  |
-| issue  |   | Yes  |
-| page_number  |   | Yes  |
-| section_title  |   | Yes  |
-| section_policy  |   | Yes  |
-| section_reference  |   | Yes  |
-| doi  |   | Yes  |
-| author_given_name_x  |   | Yes  |
-| author_family_name_x |   | Yes  |
+| file  | A full path to the file  | Yes  |
+| publication_date  | the date of publication, structured as yyyy-mm-dd | Yes  |
+| volume  | the volume number | Yes  |
+| year  | year of the issue  | Yes  |
+| issue  | the issue number, as a string  | Yes  |
+| page_number  |  the page numbers | Yes  |
+| section_title  | the title of the section  | Yes  |
+| section_policy  | the section policy  | Yes  |
+| section_reference  |  the short code for the section | Yes  |
+| doi  |  the full DOI | no  |
+| author_given_name_x  | first name of the author  | Yes  |
+| author_family_name_x | last name of the author | Yes  |
 
 ## `ojs-xml-generator.py` 
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ It contains a method `validate_csv` that can be used in your CSV processor.
 python output_csv_validator.py --csv /path/to/data.csv
 ```
 
+### Explanation of intermediate CSV fields
+| Field  | Contents  | Required?  |
+|---|---|---|
+| id  | Just a numerical ID  | Yes  |
+| title  | The title of the article  | Yes  |
+| publication | The title of the issue | Yes |
+| abstract  | The abstract of the article  | Yes  |
+| file  |   | Yes  |
+| publication_date  |   | Yes  |
+| volume  |   | Yes  |
+| year  |   | Yes  |
+| issue  |   | Yes  |
+| page_number  |   | Yes  |
+| section_title  |   | Yes  |
+| section_policy  |   | Yes  |
+| section_reference  |   | Yes  |
+| doi  |   | Yes  |
+| author_given_name_x  |   | Yes  |
+| author_family_name_x |   | Yes  |
 
 ## `ojs-xml-generator.py` 
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ python output_csv_validator.py --csv /path/to/data.csv
 | section_policy  | the section policy (won't be shown)  | Yes  |
 | section_reference  |  the short code for the section (won't be shown, but should be the same for every instance of section title x) | Yes  |
 | doi  |  the full DOI | no  |
-| author_given_name_x  | first name of the author  | Yes  |
-| author_family_name_x | last name of the author | Yes  |
+| author_given_name_x  | first name of the author. Make sure they're empty if there is no author x.  | Yes  |
+| author_family_name_x | last name of the author. Make sure they're empty if there is no author x. | Yes  |
 
 ## `ojs-xml-generator.py` 
 

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ python output_csv_validator.py --csv /path/to/data.csv
 ### Explanation of intermediate CSV fields
 | Field  | Contents  | Required?  |
 |---|---|---|
-| id  | Just a numerical ID  | Yes  |
+| id  | A numberical ID, from 1 to X  | Yes  |
 | title  | The title of the article  | Yes  |
-| publication | The title of the issue | Yes |
+| publication | The title of the issue, if it has one (e.g. themed issues) | Yes |
 | abstract  | The abstract of the article  | Yes  |
-| file  | A full path to the file  | Yes  |
+| file  | A full path to the file corresponding with the article text  | Yes  |
 | publication_date  | the date of publication, structured as yyyy-mm-dd | Yes  |
 | volume  | the volume number | Yes  |
 | year  | year of the issue  | Yes  |
 | issue  | the issue number, as a string  | Yes  |
 | page_number  |  the page numbers | Yes  |
 | section_title  | the title of the section  | Yes  |
-| section_policy  | the section policy  | Yes  |
-| section_reference  |  the short code for the section | Yes  |
+| section_policy  | the section policy (won't be shown)  | Yes  |
+| section_reference  |  the short code for the section (won't be shown, but should be the same for every instance of section title x) | Yes  |
 | doi  |  the full DOI | no  |
 | author_given_name_x  | first name of the author  | Yes  |
 | author_family_name_x | last name of the author | Yes  |


### PR DESCRIPTION
Added an explanation of what the fields of the CSV need to contain, based on [output_csv_validator.py](https://github.com/knaw-huc/ojs-tools/blob/master/output_csv_validator.py). 

This is helpful as a reference both for users of the scripts, as well as the editors of journals who we ask to check and/or add to the CSV files.